### PR TITLE
Optimizations

### DIFF
--- a/src/distributor/distributor.ts
+++ b/src/distributor/distributor.ts
@@ -108,7 +108,9 @@ class Distributor {
         const baseTxEstimate = await this.runtimeEstimator.EstimateBaseTx();
         const baseGasPrice = await this.runtimeEstimator.GetGasPrice();
 
-        const baseTxCost = baseGasPrice.mul(baseTxEstimate).add(inherentValue);
+        // add some more tokens to base tx cost if london fork is enabled,
+        // since base fee dynamically expands
+        const baseTxCost = baseGasPrice.mul(baseTxEstimate).add(inherentValue).mul(10);
 
         // Calculate how much each sub-account needs
         // to execute their part of the run cycle.
@@ -231,10 +233,12 @@ class Distributor {
         });
 
         for (const acc of accounts) {
-            await this.ethWallet.sendTransaction({
+            const response = await this.ethWallet.sendTransaction({
                 to: acc.address,
                 value: acc.missingFunds,
             });
+            
+            await response.wait();
 
             fundBar.increment();
             this.readyMnemonicIndexes.push(acc.mnemonicIndex);

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,9 +134,7 @@ async function run() {
     // Collect the data
     const collectorData = await new StatCollector().generateStats(
         txHashes,
-        mnemonic,
         url,
-        batchSize
     );
 
     // Output the data if needed

--- a/src/outputter/outputter.ts
+++ b/src/outputter/outputter.ts
@@ -4,10 +4,14 @@ import { BlockInfo, CollectorData } from '../stats/collector';
 
 class outputFormat {
     averageTPS: number;
+    minTPS: number;
+    maxTPS: number;
     blocks: BlockInfo[];
 
-    constructor(averageTPS: number, blocks: BlockInfo[]) {
+    constructor(averageTPS: number, minTPS: number, maxTPS: number, blocks: BlockInfo[]) {
         this.averageTPS = averageTPS;
+        this.minTPS = minTPS;
+        this.maxTPS = maxTPS;
         this.blocks = blocks;
     }
 }
@@ -24,7 +28,7 @@ class Outputter {
         try {
             FileSystem.writeFile(
                 path,
-                JSON.stringify(new outputFormat(data.tps, blocks)),
+                JSON.stringify(new outputFormat(data.tps, data.minTps, data.maxTps, blocks)),
                 (error) => {
                     if (error) throw error;
                 }

--- a/src/runtime/signer.ts
+++ b/src/runtime/signer.ts
@@ -100,17 +100,40 @@ class Signer {
         });
 
         const signedTxs: string[] = [];
+        const numTxs = transactions.length;
+        const numAccounts = accounts.length;
+        const txsPerAccount = Math.floor(numTxs/ numAccounts);
+        const remainingTxs = numTxs % numAccounts;
 
-        for (let i = 0; i < transactions.length; i++) {
-            const sender = accounts[i % accounts.length];
+        let k = 0;
+        for (let i = 0; i < numAccounts; i++) {
+            const sender = accounts[i];
 
+            for (let j = 0; j < txsPerAccount; j++) {
+                try {
+                    signedTxs.push(
+                        await sender.wallet.signTransaction(transactions[k])
+                    );
+                } catch (e: any) {
+                    failedTxnSignErrors.push(e);
+                }
+
+                k++;
+                signBar.increment();
+            }
+        }
+
+        const account = accounts[accounts.length - 1];
+        for (let i = 0; i < remainingTxs; i++) {
             try {
                 signedTxs.push(
-                    await sender.wallet.signTransaction(transactions[i])
+                    await account.wallet.signTransaction(transactions[k])
                 );
             } catch (e: any) {
                 failedTxnSignErrors.push(e);
             }
+
+            k++;
 
             signBar.increment();
         }

--- a/src/stats/collector.ts
+++ b/src/stats/collector.ts
@@ -314,8 +314,12 @@ class StatCollector {
     }
 
     async waitForTxPoolToEmpty(url: string, numOfTxs: number): Promise<boolean> {
-        const timeout = numOfTxs * 500; // assume a transaction needs half a second
+        let timeout = numOfTxs * 500; // assume a transaction needs half a second
         let stopFlag = false;
+
+        if (timeout < 1000) {
+            timeout = 5000 // Set a minimum timeout of 5 seconds
+        }
 
         Logger.info('\nWaiting for all transactions to be executed...');
 

--- a/src/stats/collector.ts
+++ b/src/stats/collector.ts
@@ -48,10 +48,14 @@ class BlockInfo {
 
 class CollectorData {
     tps: number;
+    minTps: number;
+    maxTps: number;
     blockInfo: Map<number, BlockInfo>;
 
-    constructor(tps: number, blockInfo: Map<number, BlockInfo>) {
+    constructor(tps: number, minTps: number, maxTps: number, blockInfo: Map<number, BlockInfo>) {
         this.tps = tps;
+        this.minTps = minTps;
+        this.maxTps = maxTps;
         this.blockInfo = blockInfo;
     }
 }
@@ -283,7 +287,7 @@ class StatCollector {
         if (txHashes.length == 0) {
             Logger.warn('No stat data to display');
 
-            return new CollectorData(0, new Map());
+            return new CollectorData(0, 0, 0, new Map());
         }
 
         let txStats: txStats[] = [];
@@ -306,7 +310,7 @@ class StatCollector {
         const avgTPS = await this.calcTPS(txStats, blockInfoMap, provider);
         this.printFinalData(avgTPS, blockInfoMap);
 
-        return new CollectorData(avgTPS[0], blockInfoMap);
+        return new CollectorData(avgTPS[0], avgTPS[1], avgTPS[2], blockInfoMap);
     }
 
     async waitForTxPoolToEmpty(url: string, numOfTxs: number): Promise<boolean> {

--- a/src/stats/collector.ts
+++ b/src/stats/collector.ts
@@ -100,10 +100,14 @@ class StatCollector {
                 const txReceipt = await provider.waitForTransaction(
                     txHash,
                     1,
-                    60 * 10000
+                    2 * 60 * 1000 // 2 minutes
                 );
 
-                if (txReceipt.status != undefined && txReceipt.status == 0) {
+                if (txReceipt == null) {
+                    throw new Error(
+                        `transaction ${txHash} failed to be fetched in time`
+                    );
+                } else if (txReceipt.status != undefined && txReceipt.status == 0) {
                     throw new Error(
                         `transaction ${txHash} failed during execution`
                     );


### PR DESCRIPTION
This PR introduces couple of optimizations to the load test tool:

1. Waiting for accounts to be funded in the `distributor`. This is done because, on networks with London (EIP-1559) fork (where there can not be "free" transactions), these fund transactions were sent without waiting for them to be mined, and load test started, but, since those txs were not mined, a bunch of txs those accounts sent get rejected by transaction pool since those accounts don't have balance yet. That is why, this PR introduced waiting for fund transactions to finish, and then start load test.
2. introduced a wait for tx pool to be emptied mechanism in `collector`. It basically polls the tx pool every 2s to see if all txs got executed, before collecting receipts. This is done to stop spamming the node for receipts of txs that were not mined yet, plus, it will make the receipts collection faster since all the txs will be mined when this loop finishes. This loop assumes that half a second is needed for one txs, so it dynamically calculates the timeout to stop the loop if tx pool does not empty in time.
3. It optimizes receipt collection by caching tx hashes of blocks. It first collects a receipt of a transaction that is not in cache, and also polls its block and caches all the transactions in that block. This makes receipt collection much faster, since all the transactions in the load tests are bundled together in consecutive blocks. They are not scattered around.